### PR TITLE
[KS-SER-07-km] 주식 조회를 stock-api 에서 크롤링 한다.

### DIFF
--- a/server/stock-api/build.gradle.kts
+++ b/server/stock-api/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     // tomcat
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 
+    // Crawling
+    implementation("org.jsoup:jsoup:1.13.1")
+
     // swagger
     @Suppress("DEPRECATION")
     compile( group= "io.springfox", name= "springfox-swagger-ui", version= "2.9.2")

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/controller/GetStockDirectlyController.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/controller/GetStockDirectlyController.kt
@@ -1,0 +1,29 @@
+package study.kstock.stockapi.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import study.kstock.stockapi.domain.StockData
+import study.kstock.stockapi.message.ResponseFactory
+import study.kstock.stockapi.service.StockDataCrawlingService
+import javax.annotation.Resource
+
+@RestController
+class GetStockDirectlyController {
+
+    @Resource
+    private lateinit var stockDataCrawlingService: StockDataCrawlingService
+
+    @GetMapping("search/{symbol}")
+    fun getStockListBySymbol(@PathVariable symbol: String): ResponseEntity<StockData?> {
+        val result = stockDataCrawlingService.searchStockData(symbol)
+        return ResponseFactory.createResponse(result)
+    }
+
+    @GetMapping("stock/list/{region}/{market}/{start}")
+    suspend fun getArrayOf20Stocks(@PathVariable region: String, @PathVariable market: String, @PathVariable start: Int): ResponseEntity<ArrayList<StockData>?> {
+        val result = stockDataCrawlingService.getRecentStockDataListOf(region, market, start)
+        return ResponseFactory.createResponse(result)
+    }
+}

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/controller/StockServiceController.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/controller/StockServiceController.kt
@@ -23,10 +23,4 @@ class StockServiceController {  // stock-core 서버에 요청하여 결과를 �
         return ResponseFactory.createResponse(result)
     }
 
-    @GetMapping("stock/list/{market}/{start}")
-    suspend fun getArrayOf20Stocks(@PathVariable market: String, @PathVariable start: Int): ResponseEntity<MutableList<Any>> {
-        val result = stockService.getArrayOf20Stocks(market, start)
-        return ResponseFactory.createResponse(result)
-    }
-
 }

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockData.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockData.kt
@@ -1,0 +1,5 @@
+package study.kstock.stockapi.domain
+
+import java.math.BigDecimal
+
+data class StockData(val stockSymbol: StockSymbol, val lastPrice: BigDecimal, val priceChange: BigDecimal, val percentChange: BigDecimal)

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockMarket.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockMarket.kt
@@ -1,0 +1,3 @@
+package study.kstock.stockapi.domain
+
+data class StockMarket(var market: String, var region: String)

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockSymbol.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/domain/StockSymbol.kt
@@ -1,0 +1,3 @@
+package study.kstock.stockapi.domain
+
+data class StockSymbol(var symbol: String, var name: String, var stockMarket: StockMarket)

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/message/ResponseFactory.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/message/ResponseFactory.kt
@@ -10,5 +10,10 @@ class ResponseFactory {
             val status = if (result.isEmpty()) HttpStatus.NOT_FOUND else HttpStatus.OK
             return ResponseEntity(result, status)
         }
+
+        fun <T> createResponse(result: T): ResponseEntity<T> {
+            val status = if (result == null) HttpStatus.NOT_FOUND else HttpStatus.OK
+            return ResponseEntity(result, status)
+        }
     }
 }

--- a/server/stock-api/src/main/kotlin/study/kstock/stockapi/service/StockDataCrawlingService.kt
+++ b/server/stock-api/src/main/kotlin/study/kstock/stockapi/service/StockDataCrawlingService.kt
@@ -1,0 +1,72 @@
+package study.kstock.stockapi.service
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
+import org.springframework.stereotype.Service
+import study.kstock.stockapi.domain.StockData
+import study.kstock.stockapi.domain.StockMarket
+import study.kstock.stockapi.domain.StockSymbol
+import java.math.BigDecimal
+
+@Service
+class StockDataCrawlingService {
+
+    fun searchStockData(symbolString: String): StockData? {
+
+        // TODO
+        //  1. 미국 주식 거래소 목록 강제로 박음
+        //  2. null 처리 깔끔하지 않은 부분 수정 필요
+        val marketList = arrayOf("nyse", "amex", "nasd")
+        var stockDataElement = Elements()
+        var foundMarket = ""
+        for (market in marketList) {
+            val url = "https://finviz.com/screener.ashx?v=111&f=exch_${market}&t=${symbolString}"
+            val document = Jsoup.connect(url).get().body()
+            stockDataElement = document.getElementsByClass("table-dark-row-cp")
+            if (stockDataElement.isNotEmpty()) {
+                foundMarket = market
+                break
+            }
+        }
+        if (stockDataElement.isEmpty()) return null
+
+        return getStockDataBy(stockDataElement[0], foundMarket)
+    }
+
+    fun getRecentStockDataListOf(region: String, market: String, start: Int): ArrayList<StockData>? {
+        val url = "https://finviz.com/screener.ashx?v=111&f=exch_${market},geo_${region}&r=${start}"
+        val stockDataList = ArrayList<StockData>()
+        val document = Jsoup.connect(url).get().body()
+        val stockDataElements = Elements()
+        val parentsOne = document.getElementsByClass("table-light-row-cp")
+        val parentsTwo = document.getElementsByClass("table-dark-row-cp")
+        stockDataElements.addAll(parentsOne)
+        stockDataElements.addAll(parentsTwo)
+
+        if (stockDataElements.isEmpty()) return null
+
+        for (stockDataElement in stockDataElements) {
+            val stockData = getStockDataBy(stockDataElement, market)
+            stockDataList.add(stockData)
+        }
+
+        return stockDataList
+    }
+
+    private fun getStockDataBy(stockDataElement: Element, market: String): StockData {
+        val symbol = stockDataElement.child(1).text()
+        val name = stockDataElement.child(2).text()
+        val region = stockDataElement.child(5).text()
+        val lastPrice = BigDecimal(stockDataElement.child(8).text())
+        val percentChange = BigDecimal(stockDataElement.child(9).text().substringBefore('%'))
+        val priceChange = lastPrice - lastPrice / (BigDecimal.ONE + (percentChange * BigDecimal(0.01)))
+        return StockData(
+            StockSymbol(
+                symbol, name,
+                StockMarket(market, region)
+            ),
+            lastPrice, priceChange, percentChange
+        )
+    }
+}

--- a/server/stock-api/src/test/kotlin/study/kstock/stockapi/service/StockDataCrawlingServiceTest.kt
+++ b/server/stock-api/src/test/kotlin/study/kstock/stockapi/service/StockDataCrawlingServiceTest.kt
@@ -1,0 +1,51 @@
+package study.kstock.stockapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+internal class StockDataCrawlingServiceTest {
+
+    @Autowired
+    private lateinit var stockDataCrawlingService: StockDataCrawlingService
+    private val logger: Logger = LoggerFactory.getLogger(StockDataCrawlingServiceTest::class.java)
+
+    @DisplayName("AEVA 주식을 검색하면 null이 아니다")
+    @Test
+    fun searchStockData() {
+        // given
+        val symbol = "AEVA"
+
+        // when
+        val result = stockDataCrawlingService.searchStockData(symbol)
+        logger.info("조회 결과: $result")
+
+        // then
+        assertThat(result).isNotNull
+    }
+
+    @DisplayName("인덱스 1번부터 20번까지 USA 지역의 나스닥 주식데이터를 웹크롤링해서 가져오는데 걸리는 시간은 3초 미만이다")
+    @Test
+    internal fun getStockDataTimeCheckTest() {
+        // given
+        val market = "nasd"
+        val region = "usa"
+        val start = 1
+
+        // when
+        val startTime = System.currentTimeMillis()
+        val endTime = System.currentTimeMillis()
+        val timeTaken = endTime - startTime
+        logger.info("걸린시간 ${timeTaken.toDouble() / 1000}초")
+        stockDataCrawlingService.getRecentStockDataListOf(region, market, start)
+            ?.forEach { stockData -> logger.info(stockData.toString()) }
+
+        // then
+        assertThat(timeTaken).isLessThan(3000)
+    }
+}


### PR DESCRIPTION
## Fixes
처음 설계는 stock-external에서 모든 주식 데이터를 호출하려고  했으나, 워낙 주식 데이터가 방대하고, 주식 API로 모든 주식 데이터를 계속해서 받아오는 것도 무리가 있기에 비로그인 방식의 주식 조회 서비스로 1차 개발 시에는 stock-api에서 stock-core를 경유하지 않고 바로 웹 크롤링을 통해 주식데이터를 빠르게 조회하여 Android 앱으로 반환할 수 있도록 구현합니다.

관련 이슈: #23 